### PR TITLE
Correct the savings plan permissions

### DIFF
--- a/src/docs/cloud-analyzer/tutorials/cloud-analyzer-policy/README.md
+++ b/src/docs/cloud-analyzer/tutorials/cloud-analyzer-policy/README.md
@@ -18,7 +18,8 @@ Use this policy only if you know the Role ARN associated with Cloud Analyzer.
         "cloudformation:ListStackResources",
         "dynamodb:List*",
         "dynamodb:Describe*",
-        "savingsplans:*",
+        "savingsplans:List*",
+        "savingsplans:Describe*",
         "ec2:Describe*",
         "ec2:List*",
         "ec2:GetHostReservationPurchasePreview",
@@ -106,6 +107,8 @@ The following are read-only permissions for the reserved capacity reservations.
 ```
 "dynamodb:List*"
 "dynamodb:Describe*"
+"savingsplans:List*",
+"savingsplans:Describe*",
 "ec2:Describe*"
 "ec2:List*"
 "ec2:GetHostReservationPurchasePreview"


### PR DESCRIPTION
Change from FULL PERMISSION (savingsplans:*) to READ ONLY permissions. Add the savings plans lines to the Reserved Capacity context section.