### PR TITLE
fix(docs): replace advanced with CAPACITY SETTINGS

### DIFF
--- a/src/docs/tools-and-provisioning/ci-cd/jenkins.md
+++ b/src/docs/tools-and-provisioning/ci-cd/jenkins.md
@@ -115,7 +115,7 @@ That's all! From now on, the Jenkins controller will automatically launch new in
 
 #### Jenkins on AWS
 
-Create an Elastigroup with your preferred Region, AMI, and Instance Types. In the General tab, under CAPACITY SETTINGS, set the Capacity Unit to _vCPU_.
+Create an Elastigroup with your preferred Region, AMI, and Instance Types. In the General tab under Capacity Settings, set the Capacity Unit to _vCPU_.
 
 <img src="/tools-and-provisioning/_media/Jenkins_2.png" />
 

--- a/src/docs/tools-and-provisioning/ci-cd/jenkins.md
+++ b/src/docs/tools-and-provisioning/ci-cd/jenkins.md
@@ -115,7 +115,7 @@ That's all! From now on, the Jenkins controller will automatically launch new in
 
 #### Jenkins on AWS
 
-Create an Elastigroup with your preferred Region, AMI, and Instance Types. In the General tab under Advanced set the Capacity Unit to _vCPU_.
+Create an Elastigroup with your preferred Region, AMI, and Instance Types. In the General tab, under CAPACITY SETTINGS, set the Capacity Unit to _vCPU_.
 
 <img src="/tools-and-provisioning/_media/Jenkins_2.png" />
 


### PR DESCRIPTION
`advanced` section doesnt appear to exist anymore, updated to match section heading `CAPACITY SETTINGS`