### PR TITLE
Remove instance type whitelist from Wave getting started documentation

### DIFF
--- a/src/docs/wave/getting-started/README.md
+++ b/src/docs/wave/getting-started/README.md
@@ -91,14 +91,7 @@ nodeGroups:
 
             # Number of units to retain as headroom, where each unit has the
             # defined CPU and memory.
-            numOfUnits: 2
-      compute:
-        instanceTypes:
-          # Instance types allowed in the Ocean cluster. Cannot be configured
-          # if the blacklist is configured.
-          whitelist: # OR blacklist
-            - t2.large
-            - c5.large
+            numOfUnits: 2      
 ```
 
 2. To create the cluster, enter the following command:

--- a/src/docs/wave/getting-started/README.md
+++ b/src/docs/wave/getting-started/README.md
@@ -53,8 +53,8 @@ nodeGroups:
       metadata:
         # these metadata fields will be deprecated in the future, but
         # are necessary for autoscaling today
-    	 defaultLaunchSpec: true
-    	 useAsTemplateOnly: false
+        defaultLaunchSpec: true
+        useAsTemplateOnly: false
 
 
       strategy:
@@ -91,7 +91,7 @@ nodeGroups:
 
             # Number of units to retain as headroom, where each unit has the
             # defined CPU and memory.
-            numOfUnits: 2      
+            numOfUnits: 2
 ```
 
 2. To create the cluster, enter the following command:


### PR DESCRIPTION
- Remove instance type whitelist - all instance types should be allowed at the cluster level
- Later on we will add documenation around setting up VNGs with select instance types