### PR TITLE
Add note about Athena integration

### DIFF
--- a/src/docs/eco/getting-started/connect-your-aws-account.md
+++ b/src/docs/eco/getting-started/connect-your-aws-account.md
@@ -41,6 +41,8 @@ Set up Cost and Usage Reports as described below.
    - Enable report data integration for Amazon Athena.
 3. Mark the checkboxes as shown below.
 
+> **Note**: We strongly recommend that you create both a new Amazon S3 bucket and a new Cost and Usage Reports if you do not have Athena already integrated. The following setup process removes any Amazon S3 events that your bucket might already have, which can negatively affect any existing event-based processes that you have for an existing AWS CUR.
+
 <img src="/eco/_media/gettingstarted-aws-connect-03.png" />
 
 <img src="/eco/_media/gettingstarted-aws-connect-04.png" />


### PR DESCRIPTION
Add note about Athena integration. This is intended to be a warning message for customers who have existing CURs that they may be editing to use with ECO/CA. The customer should be aware that by checking the Athena integration, it will make changes to the S3 bucket.