### PR TITLE
Update ansible.md

### DIFF
--- a/src/docs/tools-and-provisioning/ansible.md
+++ b/src/docs/tools-and-provisioning/ansible.md
@@ -2,10 +2,11 @@
 
 Ansible is an open-source software provisioning, configuration management, and application-deployment tool enabling infrastructure as code.
 
-Spot integration with Ansible enables you to use an Ansible module to create, update, and delete Elastigroups running with the Spot platform on AWS.
+Spot integration with Ansible enables you to use an Ansible module to create, update, and delete [resources](need to create a new page here) running with the Spot platform on AWS.
 
 To install the Ansible module for Spot, go to the documentation on [Github](https://github.com/spotinst/spotinst-ansible-module).
 
+
 ## What's Next?
 
-For a detailed reference of commands you can use in the Ansible module and code samples, see the [Spot AWS Elastigroup Module](https://docs.ansible.com/ansible/latest/collections/community/general/spotinst_aws_elastigroup_module.html#spotinst-aws-elastigroup-module) documentation.
+Try out one of the many example templates available in our [Github repository](https://github.com/spotinst/spotinst-ansible-module/tree/master/examples).


### PR DESCRIPTION
In the "resources" hyperlink - we need to create a new page that contains the resources we support, the same as we have with CloudFormation (on this page https://docs.spot.io/tools-and-provisioning/cloudformation/getting-started/resource-types).
The resources we are supporting in Ansible are:
* Spot Elastigroup - spotinst_aws_elastigroup
* Spot Elastigroup for Amazon EMR – spotinst_aws_mrscaler
* Spot Managed Instance - spotinst_aws_managed_instance
* Spot Ocean - spotinst_ocean_cloud
* Spot Notification Service (Subscription) – spotinst_event_subscription