### PR TITLE
Add RoleAssignment read access to Spot Azure Policy

### DIFF
--- a/src/docs/administration/api/spot-policy-in-azure.md
+++ b/src/docs/administration/api/spot-policy-in-azure.md
@@ -7,6 +7,7 @@ The latest Spot policy in Azure appears below.
     "permissions": [
       {
         "actions": [
+          "Microsoft.Authorization/roleAssignments/read",
           "Microsoft.Compute/availabilitySets/read",
           "Microsoft.Compute/availabilitySets/vmSizes/read",
           "Microsoft.Compute/disks/read",


### PR DESCRIPTION
For Kubenet clusters this is a requirement as we need to give the
cluster MSI access to update the route table. To validate this access on
cluster creation we need to be able to read the Role Assigment on the
route table.