### PR TITLE
Missing link

### DIFF
--- a/src/docs/ocean/getting-started/eks/join-an-existing-cluster.md
+++ b/src/docs/ocean/getting-started/eks/join-an-existing-cluster.md
@@ -60,7 +60,7 @@ In this procedure, you will use the [Spot Console](http://console.spotinst.com/)
 The Connectivity page provides steps for you to install the Ocean Controller and establish the connection between the Ocean SaaS and the cluster. Complete the steps as described on the page and summarized below.
 
 1. Create a Spot token (or use an existing one) and copy it to the text box.
-2. Use the kubectl command-line tool to install the Ocean Controller Pod. Learn more about the Ocean Controller Pod and Ocean's anatomy here.
+2. Use the kubectl command-line tool to install the Ocean Controller Pod. Learn more about the Ocean Controller Pod and Ocean's anatomy [here](ocean/tutorials/spot-kubernetes-controller).
 3. Click Test Connectivity to ensure the controller functionality. Allow approximately two minutes for the test to complete.
 4. Click Next.
 


### PR DESCRIPTION
This line appears to be missing a link, I think to the controller pod page but that should be verified.

"Use the kubectl command-line tool to install the Ocean Controller Pod. Learn more about the Ocean Controller Pod and Ocean's anatomy here."

_This is the default pull request template. You can customize it by adding a `pull_request_template.md` at the root of your repo or inside the `.github` folder._

# Jira Ticket

_Include a link to your Jira Ticket_
_Example: [JIRAISS-1234](https://spotinst.atlassian.net/browse/JIRAISS-1234)_

# Demo

_Please add a recording of the feature/bug fix in work. if you added new routes, the recording should show the request and response for each new/changed route_

# Checklist:
- [ ] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [ ] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have validated all the requirements in the Jira task were answered
- [ ] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
