### PR TITLE
Fix Quotes sign in JSON block for Ocean Spark

### DIFF
--- a/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
+++ b/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
@@ -20,7 +20,7 @@ curl -X POST \
     "sparkVersion": "3.2.0",
     "mainApplicationFile": "s3a://my-example-bucket/word_count.py",
     "image": "gcr.io/datamechanics/spark:platform-3.2-latest",
-    "arguments": [“s3a://my-example-bucket/input/*”, “s3a://my-example-bucket/output”]
+    "arguments": [“s3a://my-example-bucket/input/*", “s3a://my-example-bucket/output"]
   }
 }'
 ```
@@ -257,7 +257,7 @@ curl -X POST \
    "sparkVersion": "3.2.0",
    "image": "gcr.io/datamechanics/spark:platform-3.2-latest",
    "mainApplicationFile": "s3a://my-example-bucket/word_count.py",
-   "arguments": [“s3a://my-example-bucket/input/*”, “s3a://my-example-bucket/output”],
+   "arguments": [“s3a://my-example-bucket/input/*", “s3a://my-example-bucket/output"],
 "driver": {
       "envSecretKeyRefs": {
         "AWS_ACCESS_KEY_ID": {

--- a/src/docs/ocean-spark/configure-spark-apps/package-spark-code.md
+++ b/src/docs/ocean-spark/configure-spark-apps/package-spark-code.md
@@ -141,7 +141,7 @@ curl -X POST \
          "jobId": "my-job",
          "configOverrides": {
            "type": "Python",
-           “sparkVersion”: “3.2.0”,
+           "sparkVersion": "3.2.0",
            "image": "<account-id>.dkr.ecr.<region>.amazonaws.com/my-app:dev",
            "mainApplicationFile": "local:///opt/spark/work-dir/main.py",
            "arguments": [<args>]
@@ -163,7 +163,7 @@ curl -X POST \
          "jobId": "my-job",
          "configOverrides": {
            "type": "Scala",
-           “sparkVersion”: “3.2.0”,
+           "sparkVersion": "3.2.0",
            "image": "<account-id>.dkr.ecr.<region>.amazonaws.com/my-app:dev",
            "mainApplicationFile": "local:///opt/spark/work-dir/main.jar",
            "mainClass": "<className>",

--- a/src/docs/ocean-spark/getting-started/run-your-first-app.md
+++ b/src/docs/ocean-spark/getting-started/run-your-first-app.md
@@ -95,9 +95,6 @@ The API then returns something like:
                      "KUBERNETES_REQUEST_TIMEOUT":"30000",
                      "KUBERNETES_CONNECTION_TIMEOUT":"30000"
                   },
-                  "affinity":"“"{
-                     "..."
-                  }"”",
                   "instanceType":"m5.xlarge",
                   "spot":false
                },
@@ -106,9 +103,6 @@ The API then returns something like:
                   "instances":1,
                   "coreRequest":"3460m",
                   "memory":"8192m",
-                  "affinity":"“"{
-                     "..."
-                  }"”",
                   "instanceType":"m5.xlarge",
                   "spot":true
                },


### PR DESCRIPTION
Google doc replaces proper quote sign " with the sign ”
They're not the same, ” isn't valid JSON.
So our users can't copy paste the examples from the docs.