### PR TITLE
Add GCP support to Ocean Spark doc + custom service account

### DIFF
--- a/src/docs/ocean-spark/configure-spark-apps/README.md
+++ b/src/docs/ocean-spark/configure-spark-apps/README.md
@@ -24,7 +24,7 @@ Config overrides are fragments of configuration that you define when submitting 
 curl -k -X POST \
   'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer ...' \
+  -H 'Authorization: Bearer <your-spot-token>' \
   -d '{
   "jobId": "spark-pi",
   "configOverrides": {

--- a/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
+++ b/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
@@ -12,7 +12,7 @@ Here’s the payload you would submit:
 curl -X POST \
   'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00' \
+  -H 'Authorization: Bearer <your-spot-token>' \
   -d '{
   "jobId": "spark-pi",
   "configOverrides": {
@@ -273,7 +273,7 @@ You can now modify the payload to launch the Spark application in order to refer
 curl -X POST \
 'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00' \
+ -H 'Authorization: Bearer <your-spot-token>' \
  -d '{
  "job-id": "spark-pi",
  "configOverrides": {
@@ -315,7 +315,7 @@ curl -X POST \
 
 Create a service account in the GCP console, and grant it sufficient permissions using [IAM roles](https://cloud.google.com/iam/docs/overview). The list of IAM roles for GCS is [here](https://cloud.google.com/storage/docs/access-control/iam-roles).
 
-This bash script will create an access key for the service account, and store it in a secret called data-access in the Kubernetes namespace where Data Mechanics Spark applications are run:
+This bash script will create an access key for the service account, and store it in a secret called `data-access` in the Kubernetes namespace `spark-apps` where Spark applications are run:
 
 ```
 TMP_FILE=$(mktemp)
@@ -329,7 +329,7 @@ Modify the payload to launch the Spark application in order to reference the sec
 curl -X POST \
 'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00' \
+ -H 'Authorization: Bearer <your-spot-token>' \
  -d '{
  "job-id": "spark-pi",
  "configOverrides": {
@@ -439,7 +439,7 @@ Here is a full example:
 curl -X POST \
 'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00' \
+ -H 'Authorization: Bearer <your-spot-token>' \
  -d '{
  "job-id": "spark-pi",
  "configOverrides": {

--- a/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
+++ b/src/docs/ocean-spark/configure-spark-apps/access-your-data.md
@@ -199,7 +199,7 @@ Once you have found the service account, grant it sufficient permissions using [
 
 ### AWS
 
-Spark pods can impersonate an IAM user (AWS) when provided with the user’s credentials. This technique completely overrides the IAM role assumed by the Kubernetes nodes (see previous section, "Granting permissions to node instances”).
+Spark pods can impersonate an IAM user (AWS) when provided with the user’s credentials. This technique completely overrides the IAM role assumed by the Kubernetes nodes (see previous section, Granting permissions to node instances).
 
 To protect those credentials, you will store them in Kubernetes secrets and configure Spark to mount those secrets into all the driver and executor pods as [environment variables](ocean-spark/configure-spark-apps/secrets-environment-variables).
 

--- a/src/docs/ocean-spark/configure-spark-apps/package-spark-code.md
+++ b/src/docs/ocean-spark/configure-spark-apps/package-spark-code.md
@@ -107,7 +107,7 @@ where `<args>` are the arguments to be passed to the application main class `<cl
 
 The simplest option on AWS is to use the Elastic Container Registry (ECR) of the account where the Ocean Spark platform is deployed. This way, the Spark pods can pull the Docker images without needing extra permissions.
 
-1. Navigate to the [ECR console](https://console.aws.amazon.com/ecr/repositories) and create a repository with name my-app in the account where the Data Mechanics is deployed. Make sure to create it in the same region as the Ocean Spark cluster to avoid transfer costs. Please refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) in case of issue.
+1. Navigate to the [ECR console](https://console.aws.amazon.com/ecr/repositories) and create a repository with name my-app in the account where the Ocean Spark cluster is deployed. Make sure to create it in the same region as the Ocean Spark cluster to avoid transfer costs. Please refer to the [AWS documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) in case of issue.
 2. Generate a temporary token so that Docker can access ECR for 12 hours with the following:
 
 `aws ecr get-login-password --region <region> | docker login --username AWS --password-stdin <account-id>.dkr.ecr.<region>.amazonaws.com`
@@ -136,7 +136,7 @@ The Spark application can now be run on Ocean Spark:
 curl -X POST \
 'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00
+ -H 'Authorization: Bearer <your-spot-token>
        --data-raw '{
          "jobId": "my-job",
          "configOverrides": {
@@ -158,7 +158,7 @@ curl -X POST \
 curl -X POST \
   'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00
+ -H 'Authorization: Bearer <your-spot-token>
        --data-raw '{
          "jobId": "my-job",
          "configOverrides": {
@@ -241,7 +241,7 @@ All required files are uploaded in your cloud storage. The Spark application can
 curl -X POST \
  'https://api.spotinst.io/ocean/spark/cluster/<your cluster id>/app?accountId=<your accountId>' \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00
+ -H 'Authorization: Bearer <your-spot-token>
  --data-raw '{
    "jobId": "my-job",
    "configOverrides": {
@@ -283,7 +283,7 @@ Reference your JAR (and its dependencies if it has any) in the configuration of 
 curl -X POST \
  https://api.spotinst.io/ocean/spark/cluster/osc-e4089a00/app \
  -H 'Content-Type: application/json' \
- -H 'Authorization: Bearer 4536dc4418995c553df9c0c0e1d31866453bcec3df0f31f97003926d67ff1e00
+ -H 'Authorization: Bearer <your-spot-token>
  --data-raw '{
    "jobId": "my-job",
    "configOverrides": {

--- a/src/docs/ocean-spark/getting-started/create-cluster.md
+++ b/src/docs/ocean-spark/getting-started/create-cluster.md
@@ -1,6 +1,7 @@
 # Create an Ocean Spark Cluster
 
 There are several ways to deploy an Ocean Spark cluster:
+
 - Create a new Kubernetes cluster from scratch
 - Import an existing Kubernetes cluster to Ocean Spark
 - Import an existing Ocean cluster to Ocean Spark
@@ -8,7 +9,8 @@ There are several ways to deploy an Ocean Spark cluster:
 Each method is described below. Choose the method right for you.
 
 ## Create a New Kubernetes Cluster from Scratch
-### Using spotctl
+
+### Using spotctl (AWS only)
 
 1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (and configure it for your AWS account), the Kubernetes [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) utility, and the [spotctl command-line tool](https://github.com/spotinst/spotctl#installation).
 
@@ -23,19 +25,20 @@ This command will create a new EKS cluster, a new VPC, subnets, and other resour
 ### Using Terraform
 
 **Option 1**: Deploy Ocean Spark cluster in an existing VPC.
-Follow [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/from-private-vpc) from the [ocean-spark Terraform module](https://registry.terraform.io/modules/spotinst/ocean-spark/spotinst/latest).
+Follow [this example on AWS](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/from-private-vpc) or [this example on GCP](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/gcp-from-vpc) from the [ocean-spark Terraform module](https://registry.terraform.io/modules/spotinst/ocean-spark/spotinst/latest).
 
 **Option 2**: Deploy Ocean Spark cluster in a new VPC.
-Follow [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/from-scratch) from the ocean-spark Terraform module.
+Follow [this example on AWS](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/from-scratch) or [this example on GCP](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/gcp-from-scratch) from the [ocean-spark Terraform module](https://registry.terraform.io/modules/spotinst/ocean-spark/spotinst/latest).
 
 ### Additional Method
 
 You can also follow the documentation on how to get started with Ocean, and then use the method described below to import an existing Ocean cluster into Ocean Spark.
 
 ## Import an Existing Kubernetes Cluster to Ocean Spark
+
 ### Using Terraform
 
-Follow [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/import-eks-cluster) from the [ocean-spark Terraform module](https://registry.terraform.io/modules/spotinst/ocean-spark/spotinst/latest) to import an existing EKS cluster into Ocean Spark.
+Follow [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/import-eks-cluster) from the [ocean-spark Terraform module](https://registry.terraform.io/modules/spotinst/ocean-spark/spotinst/latest) to import an existing EKS cluster (AWS) into Ocean Spark. To import an existing GKE cluster (GCP), use [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark/tree/main/examples/gcp-import-gke-cluster).
 
 ### Additional Method
 
@@ -45,9 +48,11 @@ You can also follow the documentation on [how to get started with Ocean](ocean/g
 
 Ocean Spark leverages Ocean under the hood, so it’s easy to import an existing Ocean cluster into Ocean Spark. Running this step will install a few additional pods on your Ocean cluster. These pods will enable the features related to monitoring and optimization specific to Apache Spark.
 
-### Using spotctl
-1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (and configure it for your AWS account), the Kubernetes [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) utility, and the [spotctl command-line tool](https://github.com/spotinst/spotctl#installation).
-2. Create a cluster by running this command, where the Ocean cluster ID is of the format o-XXXXXXXX:
+### Using spotctl (AWS only)
+
+1. Make sure you can connect to the target Kubernetes cluster with the Kubernetes [kubectl](https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html) utility. On AWS, install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) (and configure it for your AWS account).
+2. Install the [spotctl command-line tool](https://github.com/spotinst/spotctl#installation).
+3. Create a cluster by running this command, where the Ocean cluster ID is of the format o-XXXXXXXX:
 
 ```
 $ spotctl ocean spark create cluster --cluster-id $YOUR_OCEAN_CLUSTER_ID
@@ -60,6 +65,7 @@ Follow [this example](https://github.com/spotinst/terraform-spotinst-ocean-spark
 ## Monitor your Ocean Spark Cluster Deployment
 
 When you start running the script or command to create the cluster, the following major events take place:
+
 1. Kubernetes cluster creation (If creating a cluster from scratch). The duration of this step varies depending on the cloud provider, but this can take 20 minutes or more. You may be able to track progress from your cloud provider console.
 2. Ocean controller installation. The Ocean controller is installed on the cluster. The cluster is then registered with Spot and will be visible in the Spot console (under the Ocean UI).
 3. Ocean Spark controller installation. The Ocean Spark components are then installed, and the cluster will be visible in the Spot console (under the Ocean Spark UI).
@@ -68,7 +74,9 @@ You can view the status of the newly created cluster on the Cluster page of the 
 
 ## Requirements for a Functioning Ocean Spark Cluster
 
-This section provides a list of requirements for an Ocean Spark cluster deployment. The next section then puts those requirements in context by detailing common issues.
+This section provides a list of requirements for an Ocean Spark cluster deployment.
+
+### AWS
 
 - The Kubernetes cluster should run one of Kubernetes versions 1.19, 1.20, 1.21 or 1.22.
 - The VPC subnets should have the [proper tags](https://aws.amazon.com/premiumsupport/knowledge-center/eks-vpc-subnet-discovery/) to be discoverable by Kubernetes:
@@ -83,6 +91,18 @@ This section provides a list of requirements for an Ocean Spark cluster deployme
   - To connect to the Kubernetes API (which is in the cluster security group)
 - If nodes are run in private subnets, make sure a NAT gateway is available in the cluster to enable egress to the Internet.
 - All the Ocean Spark Virtual Node Groups (VNGs) should have access to the same subnets, or at least to the same availability zones (AZs).
+
+### GCP
+
+- The Kubernetes cluster should run one of Kubernetes versions 1.19, 1.20, 1.21 or 1.22.
+- The service account assumed by cluster nodes should have at least the following roles: `monitoring.viewer`, `monitoring.metricWriter`, `logging.logWriter`, and `stackdriver.resourceMetadata.writer`. More details in [this section of GCP doc](https://cloud.google.com/kubernetes-engine/docs/how-to/hardening-your-cluster#use_least_privilege_sa)
+- If Spark applications use custom Docker images stored in Container Registry, the node service account should also have `objectViewer` access to the GCS bucket where the Docker images are stored.
+- The cluster nodes should be allowed:
+  - To connect to one another
+  - To reach the Internet
+  - To connect to the Kubernetes API
+- If the cluster nodes are private, make sure a NAT service is installed in the Cloud Router of the VPC.
+- All the Ocean Spark Virtual Node Groups (VNGs) should have access to the same subnets, or at least to the same locations (also called availability zones by analogy with AWS).
 
 ## What’s Next?
 


### PR DESCRIPTION
This PR contains three changes:
* Explain how to install Ocean Spark on GCP with Terraform
* Explain how to grant data access to Spark applications on GCP
* Explain how to grant data access with a custom service account on AWS