### PR TITLE
fix classpath for SparkConnectServer

### DIFF
--- a/src/docs/ocean-spark/tools-integrations/spark-connect.md
+++ b/src/docs/ocean-spark/tools-integrations/spark-connect.md
@@ -16,7 +16,7 @@ To start a Spark application with SparkConnect server, either run the mainClass 
 ### Spark Connect Launch using the SparkConnectServer
 
 ```json
-"mainClass": "org.apache.spark.connect.sql.service.SparkConnectServer",
+"mainClass": "org.apache.spark.sql.connect.service.SparkConnectServer",
 "deps": {
     "packages": ["org.apache.spark:spark-connect_2.12:3.4.1"]
 }


### PR DESCRIPTION
Fix classpath for SparkConnectServer in documentation

# Jira Ticket

[JIRAISS-1234](https://spotinst.atlassian.net/browse/JIRAISS-1234)

# Checklist:
- [x] I have filled relevant self assessment ([NodeJS](https://docs.google.com/forms/d/e/1FAIpQLSfl14u9AOBAmxVJ272tvO7XNuXE-EMvWaGcaRZalu1UAKB7RA/viewform), [Frontend](https://docs.google.com/forms/d/e/1FAIpQLSdiBPNKH81w_EkavihVL8Uwb0j7tP8PwJmLFYm2nCOQxz-1qw/viewform), [Backend](https://docs.google.com/forms/d/e/1FAIpQLSed_PsTJ5-XIWkFL6BSDE2AQRBVPmwc3PAmHZkUn-erzVI37Q/viewform?usp=sf_link))
- [x] I have run ESlint on my changes and fixed all warnings and errors (**NodeJS & Frontend Services**)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have validated all the requirements in the Jira task were answered
- [x] I have all neccessary approvals for the design/mini design of this task
- [ ] I have approved the API changes and granular permission patterns (documentation subtask) (**For public services only**) 
