### PR TITLE
[BGD-5869] fix typo in OfAS permission page

### DIFF
--- a/src/docs/ocean-spark/configure-permissions/README.md
+++ b/src/docs/ocean-spark/configure-permissions/README.md
@@ -235,7 +235,9 @@ If you want to **force users to use a config-template when submitting an app**, 
           {
             "StringEquals": {
               "sparkClusterId": "osc-xxxxxx"
-            },
+            }
+          },
+          {
             "StringPatternMatch": {
               "sparkConfigTemplateId": "ct-team-a-*"
             }


### PR DESCRIPTION
In `condition` field, leaf conditions under operators should be enclosed in curly braces `{}`

# Jira Ticket
https://spotinst.atlassian.net/browse/DOC-2021
https://spotinst.atlassian.net/browse/BGD-5869

# Demo
<img width="1037" alt="Screenshot 2024-09-05 at 09 57 01" src="https://github.com/user-attachments/assets/7ccdc6e9-b4e3-4f37-9be2-0cc4b1643ebd">

